### PR TITLE
Default brain_test_plot() to a view-only layout for slice-based atlases

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggseg
 Title: Plotting Tool for Brain Atlases
-Version: 2.2.1.9006
+Version: 2.2.1.9007
 Authors@R: c(
     person("Athanasia Mo", "Mowinckel", , "a.m.mowinckel@psykologi.uio.no", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-5756-0223")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # ggseg 2.2.1.9000 (development)
 
+- `brain_test_plot()` now defaults to `position_brain(. ~ view)` for
+  slice-based atlases (subcortical, cerebellar, tract) and keeps
+  `position_brain(hemi ~ view)` for cortical ones. The layout is unchanged, but
+  atlas packages' snapshot tests no longer warn that `hemi` is ignored.
+
 - `position_brain()` now ignores the `hemi` term (with a warning) for
   slice-based atlases (subcortical, cerebellar, tract). Those views are whole
   slices already containing both hemispheres, so `hemi ~ view` no longer splits

--- a/R/brain-test-plot.R
+++ b/R/brain-test-plot.R
@@ -13,7 +13,9 @@
 #'
 #' @param atlas A `ggseg_atlas` object, such as [dk()] or [aseg()].
 #' @param position A `ggplot2` position adjustment arranging the brain views.
-#'   Defaults to `position_brain(hemi ~ view)`.
+#'   Defaults to `position_brain(hemi ~ view)` for cortical atlases and
+#'   `position_brain(. ~ view)` for slice-based atlases (subcortical,
+#'   cerebellar, tract), whose views already contain both hemispheres.
 #' @param na.value Fill colour for regions with no palette entry. Defaults to
 #'   `"grey"`.
 #'
@@ -26,7 +28,7 @@
 #' @export
 brain_test_plot <- function(
   atlas,
-  position = position_brain(hemi ~ view),
+  position = NULL,
   na.value = "grey"
 ) {
   if (!ggseg.formats::is_ggseg_atlas(atlas)) {
@@ -34,6 +36,14 @@ brain_test_plot <- function(
       "{.arg atlas} must be a {.cls ggseg_atlas} object.",
       "i" = "Got {.cls {class(atlas)}}."
     ))
+  }
+
+  if (is.null(position)) {
+    position <- if (identical(atlas$type, "cortical")) {
+      position_brain(hemi ~ view)
+    } else {
+      position_brain(. ~ view)
+    }
   }
 
   p <- ggplot2::ggplot() +

--- a/man/brain_test_plot.Rd
+++ b/man/brain_test_plot.Rd
@@ -4,17 +4,15 @@
 \alias{brain_test_plot}
 \title{Render a brain atlas with default snapshot styling}
 \usage{
-brain_test_plot(
-  atlas,
-  position = position_brain(hemi ~ view),
-  na.value = "grey"
-)
+brain_test_plot(atlas, position = NULL, na.value = "grey")
 }
 \arguments{
 \item{atlas}{A \code{ggseg_atlas} object, such as \code{\link[=dk]{dk()}} or \code{\link[=aseg]{aseg()}}.}
 
 \item{position}{A \code{ggplot2} position adjustment arranging the brain views.
-Defaults to \code{position_brain(hemi ~ view)}.}
+Defaults to \code{position_brain(hemi ~ view)} for cortical atlases and
+\code{position_brain(. ~ view)} for slice-based atlases (subcortical,
+cerebellar, tract), whose views already contain both hemispheres.}
 
 \item{na.value}{Fill colour for regions with no palette entry. Defaults to
 \code{"grey"}.}
@@ -24,14 +22,14 @@ A \code{\link[ggplot2:ggplot]{ggplot2::ggplot()}} object.
 }
 \description{
 Builds a minimal, deterministic plot of a \code{ggseg_atlas}: every region filled
-by its \code{label}, no legend, and \code{\link[ggplot2:ggtheme]{ggplot2::theme_void()}}. This is the canonical
+by its \code{label}, no legend, and \code{\link[ggplot2:theme_void]{ggplot2::theme_void()}}. This is the canonical
 construction used across the ggsegverse for visual-regression (\code{vdiffr})
 snapshots, so that every atlas is rendered the same way and a stray legend,
 axis, or title cannot creep into a snapshot. It doubles as a quick way to
 preview an atlas.
 }
 \details{
-The atlas \code{palette} is applied with \code{\link[ggplot2:scale_manual]{ggplot2::scale_fill_manual()}} when it is
+The atlas \code{palette} is applied with \code{\link[ggplot2:scale_fill_manual]{ggplot2::scale_fill_manual()}} when it is
 present; atlases without a palette fall back to the default \code{ggplot2} fill
 scale.
 }

--- a/man/brain_test_plot.Rd
+++ b/man/brain_test_plot.Rd
@@ -4,7 +4,11 @@
 \alias{brain_test_plot}
 \title{Render a brain atlas with default snapshot styling}
 \usage{
-brain_test_plot(atlas, position = NULL, na.value = "grey")
+brain_test_plot(
+  atlas,
+  position = NULL,
+  na.value = "grey"
+)
 }
 \arguments{
 \item{atlas}{A \code{ggseg_atlas} object, such as \code{\link[=dk]{dk()}} or \code{\link[=aseg]{aseg()}}.}
@@ -22,14 +26,14 @@ A \code{\link[ggplot2:ggplot]{ggplot2::ggplot()}} object.
 }
 \description{
 Builds a minimal, deterministic plot of a \code{ggseg_atlas}: every region filled
-by its \code{label}, no legend, and \code{\link[ggplot2:theme_void]{ggplot2::theme_void()}}. This is the canonical
+by its \code{label}, no legend, and \code{\link[ggplot2:ggtheme]{ggplot2::theme_void()}}. This is the canonical
 construction used across the ggsegverse for visual-regression (\code{vdiffr})
 snapshots, so that every atlas is rendered the same way and a stray legend,
 axis, or title cannot creep into a snapshot. It doubles as a quick way to
 preview an atlas.
 }
 \details{
-The atlas \code{palette} is applied with \code{\link[ggplot2:scale_fill_manual]{ggplot2::scale_fill_manual()}} when it is
+The atlas \code{palette} is applied with \code{\link[ggplot2:scale_manual]{ggplot2::scale_fill_manual()}} when it is
 present; atlases without a palette fall back to the default \code{ggplot2} fill
 scale.
 }

--- a/tests/testthat/test-brain-test-plot.R
+++ b/tests/testthat/test-brain-test-plot.R
@@ -30,4 +30,17 @@ describe("brain_test_plot()", {
   it("errors on a non-atlas input", {
     expect_error(brain_test_plot(1), "ggseg_atlas")
   })
+
+  it("lays out slice-based atlases by view without a hemi warning", {
+    expect_no_warning(ggplot2::ggplot_build(brain_test_plot(aseg())))
+  })
+
+  it("keeps the slice-based layout that hemi ~ view resolves to", {
+    by_view <- ggplot2::layer_data(brain_test_plot(aseg()))
+    by_hemi_and_view <- suppressWarnings(ggplot2::layer_data(
+      brain_test_plot(aseg(), position = position_brain(hemi ~ view))
+    ))
+
+    expect_identical(by_view, by_hemi_and_view)
+  })
 })


### PR DESCRIPTION
## Summary

Since #178, `position_brain()` warns and drops `hemi` for slice-based atlases (subcortical, cerebellar, tract). `brain_test_plot()` still defaulted to `position_brain(hemi ~ view)`, so every atlas package snapshotting a slice-based atlas got that warning from the helper's own default. Seen in ggsegFreeSurfer and ggsegNeuromorphometrics test runs.

`position` now defaults to `NULL`, which resolves to:
- `position_brain(hemi ~ view)` for cortical atlases (unchanged);
- `position_brain(. ~ view)` for everything else. That resolves to the same layout variable (`view`) and stacking direction (`columns`) that `hemi ~ view` ends up with after `hemi` is dropped, so snapshots don't change.

An explicit `position` argument still wins. Dev version 2.2.1.9007 with a NEWS bullet.

## Test Plan

- [x] New test: building `brain_test_plot(aseg())` emits no warning
- [x] New test: `layer_data()` of the new default is identical to the old `hemi ~ view` layout (warning suppressed)
- [x] `test-brain-test-plot.R` and `test-position-brain.R`: 107 pass, 0 fail, 0 warn; lintr clean on changed files
- [x] Full local suite: the only failures are 17 vdiffr snapshots in `test-brain-atlas-plots.R` (dk plots). The same 17 fail on a clean `origin/main` checkout locally, so they are a local rendering difference, unrelated to this change.
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)